### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.2.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ It should contain:
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * ``post_to_channel`` - Post a message to a channel. Provide a channel, message and optionally a subject

--- a/actions/post_to_channel.yaml
+++ b/actions/post_to_channel.yaml
@@ -1,6 +1,6 @@
 ---
 name: post_to_channel
-runner_type: run-python
+runner_type: python-script
 description: Post a message to a channel
 enabled: true
 entry_point: post_to_channel.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - telegram
   - messaging
   - SMS
-version : 0.1.0
+version : 0.2.0
 author : Fabio Brito
 email : psychopenguin@gmail.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.